### PR TITLE
Allow lowercase variables

### DIFF
--- a/lua/entities/gmod_wire_expression2/base/parser.lua
+++ b/lua/entities/gmod_wire_expression2/base/parser.lua
@@ -539,9 +539,14 @@ function Parser:Stmt()
 	end
 end
 
+-- Fields used on the Scope
+local Illegal = {
+	["vclk"] = true, ["lookup"] = true
+}
+
 function Parser:Variable()
 	local v = self:Consume(TokenVariant.Ident) or self:Consume(TokenVariant.LowerIdent)
-	if v and v.value == "vclk" then
+	if v and Illegal[v.value] then
 		self:Error("Illegal variable name. Sorry!")
 	end
 	return v

--- a/lua/entities/gmod_wire_expression2/core/e2lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/e2lib.lua
@@ -1002,7 +1002,6 @@ end
 
 ---@class RuntimeScope: table<string, any>
 ---@field vclk table<string, boolean>
----@field parent RuntimeScope?
 
 --- Context of an Expression 2 at runtime.
 ---@class RuntimeContext
@@ -1050,7 +1049,7 @@ RuntimeContextBuilder.__index = RuntimeContextBuilder
 
 ---@return RuntimeContextBuilder
 function RuntimeContext.builder()
-	local global = { vclk = {}, lookup = {}, parent = nil }
+	local global = { vclk = {}, lookup = {} }
 	return setmetatable({
 		GlobalScope = global,
 		Scopes = { [0] = global },

--- a/lua/wire/client/text_editor/modes/e2.lua
+++ b/lua/wire/client/text_editor/modes/e2.lua
@@ -301,6 +301,7 @@ function EDITOR:SyntaxColorLine(row)
 			else
 				addToken( "notfound", typeindex )
 			end
+
 			addToken( "operator", ":" )
 			addToken( "userfunction", funcname )
 
@@ -333,6 +334,7 @@ function EDITOR:SyntaxColorLine(row)
 			else
 				addToken( "notfound", typeindex )
 			end
+
 			addToken( "operator", ":" )
 			addToken( "userfunction", funcname )
 
@@ -367,8 +369,8 @@ function EDITOR:SyntaxColorLine(row)
 				local dots = self:SkipPattern( "%.%.%." )
 				if dots then addToken( "operator", dots ) end
 
-				local invalidInput = self:SkipPattern( "[^a-zA-Z:%[_]*" )
-				if invalidInput then addToken( "variable", invalidInput ) end
+				local invalidInput = self:SkipPattern( "[^a-z0-9A-Z:%[_]*" )
+				if invalidInput then addToken( "notfound", invalidInput ) end
 
 				if self:NextPattern( "%[" ) then -- Found a [
 					-- Color the bracket
@@ -623,6 +625,8 @@ function EDITOR:SyntaxColorLine(row)
 									addToken(tokenname, c)
 								end
 							end
+						else
+							tokenname = "notfound"
 						end
 					end
 				else

--- a/tests/expression2/compiler/compiler/restrictions/var_lookup.txt
+++ b/tests/expression2/compiler/compiler/restrictions/var_lookup.txt
@@ -1,0 +1,3 @@
+## SHOULD_FAIL:COMPILE
+
+lookup = "str"

--- a/tests/expression2/compiler/compiler/restrictions/var_vclk.txt
+++ b/tests/expression2/compiler/compiler/restrictions/var_vclk.txt
@@ -1,0 +1,3 @@
+## SHOULD_FAIL:COMPILE
+
+vclk = 2

--- a/tests/expression2/runtime/base/vars.txt
+++ b/tests/expression2/runtime/base/vars.txt
@@ -1,0 +1,15 @@
+## SHOULD_PASS:EXECUTE
+
+const Hi = 2
+assert(Hi == 2)
+
+const helloFromLowercase = 523
+assert(helloFromLowercase == 523)
+
+giveme4 = "test"
+assert(giveme4 == "test")
+
+Hi5 = 52
+hi5 = 21
+
+assert(Hi5 == 52)


### PR DESCRIPTION
### What does this PR do?

This adds the ability to use lowercase variables to E2.
They syntax highlight correctly and should work everywhere PascalCased variables work.

Resolves #17 

Only thing is `vclk` is a restricted variable name as it is used internally.
Currently not reserving any future keywords, shouldn't break that much code to add keywords later down the line.

- [ ] Documentation changes
- [x] Code changes

### How did you verify your code works?

- [x] I created tests and the test suite (`e2test`) pass on a local server