### PR TITLE
New `isTyping` implementation

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/cl_player.lua
+++ b/lua/entities/gmod_wire_expression2/core/cl_player.lua
@@ -17,10 +17,3 @@ hook.Add("OnEntityCreated", "wire_expression2_extension_player", function(ent)
 
 	SendFriendStatus()
 end)
-
--- isTyping
-hook.Add("StartChat","E2_IsTyping_Start",function() RunConsoleCommand("E2_StartChat") end)
-hook.Add("FinishChat","E2_IsTyping_Finish",function() RunConsoleCommand("E2_FinishChat") end)
-hook.Add("ShutDown", "E2_FinishChat_Remove", function()
-    hook.Remove("FinishChat", "E2_IsTyping_Finish")
-end)

--- a/lua/entities/gmod_wire_expression2/core/player.lua
+++ b/lua/entities/gmod_wire_expression2/core/player.lua
@@ -497,14 +497,9 @@ end, function(self)
 end)
 
 
--- isTyping
-local plys = {}
-concommand.Add("E2_StartChat",function(ply,cmd,args) plys[ply] = true end)
-concommand.Add("E2_FinishChat",function(ply,cmd,args) plys[ply] = nil end)
-hook.Add("PlayerDisconnected","E2_istyping",function(ply) plys[ply] = nil end)
-
 e2function number entity:isTyping()
-	return plys[this] and 1 or 0
+	if not IsValid(this) then return self:throw("Invalid player!", -1) end
+	return this:IsTyping() and 1 or 0
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
### What does this PR do?

Replaces internal implementation of E2's `e:isTyping()` to use a simple glua `Player` method, which presumably didn't exist back when this function was made.

- [ ] Documentation changes
- [x] Code changes

### How did you verify your code works?

I didn't, needs QA